### PR TITLE
[DPM-569] fix race and peform game action and newgame in same trx

### DIFF
--- a/game_sessions/usecase.go
+++ b/game_sessions/usecase.go
@@ -18,6 +18,8 @@ type UseCase interface {
 		game *models.Game,
 		user *models.User,
 		deposit string,
+		actionType uint16,
+		actionParams []uint64,
 	) (*models.GameSession, error)
 
 	GameAction(

--- a/server/api/handlers/new_game.go
+++ b/server/api/handlers/new_game.go
@@ -4,11 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"github.com/eoscanada/eos-go"
-	"github.com/rs/zerolog/log"
 	"platform-backend/contracts"
-	"platform-backend/models"
 	"platform-backend/server/api/ws_interface"
-	"time"
 )
 
 type NewGamePayload struct {
@@ -41,40 +38,18 @@ func ProcessNewGameRequest(context context.Context, req *ws_interface.ApiRequest
 		return nil, ws_interface.NewHandlerError(ws_interface.InternalError, err)
 	}
 
-	session, err := req.UseCases.GameSession.NewSession(
-		context, cas, game,
-		req.User, payload.Deposit,
-	)
-	if err != nil {
-		return nil, ws_interface.NewHandlerError(ws_interface.InternalError, err)
-	}
-
-	err = req.Repos.GameSession.AddGameSessionUpdate(context, &models.GameSessionUpdate{
-		SessionID:  session.ID,
-		UpdateType: models.SessionCreatedUpdate,
-		Timestamp:  time.Now(),
-		Data:       nil,
-	})
-	if err != nil {
-		return nil, ws_interface.NewHandlerError(ws_interface.InternalError, err)
-	}
-
 	actionParams := make([]uint64, len(payload.ActionParams))
 	for i, param := range payload.ActionParams {
 		actionParams[i] = uint64(param)
 	}
 
-	// try to instantly make first game action
-	err = req.UseCases.GameSession.GameAction(context, session.ID, payload.ActionType, actionParams)
-	if err != nil { // if error just save action to db
-		log.Debug().Msgf("Instant first action failed, saving action params for session: %d", session.ID)
-		err = req.Repos.GameSession.AddFirstGameAction(context, session.ID, &models.GameAction{
-			Type:   payload.ActionType,
-			Params: actionParams,
-		})
-		if err != nil {
-			return nil, ws_interface.NewHandlerError(ws_interface.InternalError, err)
-		}
+	session, err := req.UseCases.GameSession.NewSession(
+		context, cas, game,
+		req.User, payload.Deposit,
+		payload.ActionType, actionParams,
+	)
+	if err != nil {
+		return nil, ws_interface.NewHandlerError(ws_interface.InternalError, err)
 	}
 
 	return toGameSessionResponse(session), nil

--- a/server/app.go
+++ b/server/app.go
@@ -220,6 +220,8 @@ func NewApp(config *config.Config) (*App, error) {
 
 	uRepo := authPgRepo.NewUserPostgresRepo(db.DbPool, config.Auth.MaxUserSessions, config.Auth.RefreshTokenTTL)
 
+	subsUC := subscriptionUc.NewSubscriptionUseCase();
+
 	useCases := usecases.NewUseCases(
 		authUC.NewAuthUseCase(
 			uRepo,
@@ -236,13 +238,14 @@ func NewApp(config *config.Config) (*App, error) {
 			repos.GameSession,
 			repos.Contracts,
 			config.Blockchain.Contracts.Platform,
+			subsUC,
 		),
 		signidiceUC.NewSignidiceUseCase(
 			bc,
 			config.Blockchain.Contracts.Platform,
 			config.Signidice.Key,
 		),
-		subscriptionUc.NewSubscriptionUseCase(),
+		subsUC,
 	)
 
 	events := make(chan *eventlistener.EventMessage)


### PR DESCRIPTION
**NEW CHANGES**:
 - Fixed race between casino response and action monitor event in case of mircoforks.
 - Also now first game action and newgame packed into single trx, that should prevent race between that two transactions and avoid invalid funds deposit when first game action failed.
 - Added  `new_game` fails handling and send `failed` update to front-end if that happen.
 - Tiny logging improvements