### PR TITLE
fix: set websocket read limit 2kB

### DIFF
--- a/server/session/session.go
+++ b/server/session/session.go
@@ -23,7 +23,8 @@ const (
 	pingPeriod = (pongWait * 9) / 10
 
 	// Maximum message size allowed from peer.
-	maxMessageSize = 512
+	// TODO: need move this to config, max websocket packet size 64kB
+	maxMessageSize = 1024 * 2
 )
 
 type OnCloseCb func()


### PR DESCRIPTION
DPM-690
```
2020-10-02T13:19:59.506+03:00 [90m2020-10-02T10:19:59.506Z [0m  [33mDEBUG [0m Websocket read error, disconnection, websocket: read limit exceeded
```