### PR TITLE
fix: context from main thread in request

### DIFF
--- a/server/app.go
+++ b/server/app.go
@@ -202,39 +202,39 @@ func NewApp(config *config.Config, ctx context.Context) (*App, error) {
 	}
 
 	wsHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		wsClientHandler(app, w, r)
+		wsClientHandler(ctx, app, w, r)
 	})
 
 	authHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		authHandler(app, w, r)
+		authHandler(ctx, app, w, r)
 	})
 
 	refreshTokensHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		refreshTokensHandler(app, w, r)
+		refreshTokensHandler(ctx, app, w, r)
 	})
 
 	logoutHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		logoutHandler(app, w, r)
+		logoutHandler(ctx, app, w, r)
 	})
 
 	optOutHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		optOutHandler(app, w, r)
+		optOutHandler(ctx, app, w, r)
 	})
 
 	setEthAddrHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		setEthAddrHandler(app, w, r)
+		setEthAddrHandler(ctx, app, w, r)
 	})
 
 	claimHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		claimHandler(app, w, r)
+		claimHandler(ctx, app, w, r)
 	})
 
 	cashbacksHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		cashbacksHandler(app, w, r)
+		cashbacksHandler(ctx, app, w, r)
 	})
 
 	cashbackApproveHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		cashbackApproveHandler(app, w, r)
+		cashbackApproveHandler(ctx, app, w, r)
 	})
 
 	requestDurationHistograms := make(map[string]*prometheus.HistogramVec)


### PR DESCRIPTION
Для веб сокета контекст нужен был не запроса а основного потока, потому что походу контест запроса умирает быстро. Решил не рисковать и передать из основного потока контекст, раньше было вообще context.Background а он по идее должен быть только в main вызыван один раз. Сейчас передается через аргументы как и положено.